### PR TITLE
Fix bug in handling path.

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,10 @@
+printWidth: 120
+tabWidth: 2
+useTabs: false
+semi: true
+singleQuote: false
+jsxSingleQuote: false
+trailingComma: "es5"
+bracketSpacing: true
+arrowParens: "avoid"
+endOfLine: "auto"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,8 @@
 import { Request, Response, NextFunction } from "express";
 import * as fs from "fs";
-import {
-  HttpMethod,
-  HttpProtocol,
-  HttpRequestBuilder,
-  HttpResponseBuilder,
-  HttpExchange
-} from "http-types";
+import { HttpMethod, HttpProtocol, HttpRequestBuilder, HttpResponseBuilder, HttpExchange } from "http-types";
 
-export type HttpExchangeTransport = (
-  httpExchange: HttpExchange
-) => Promise<void>;
+export type HttpExchangeTransport = (httpExchange: HttpExchange) => Promise<void>;
 
 export interface Options {
   transports?: HttpExchangeTransport[];
@@ -19,9 +11,7 @@ export interface Options {
 type WriteCb = (error: Error | null | undefined) => void;
 type EndCb = () => void;
 
-export const LocalFileSystemTransport = (
-  filename: string
-): HttpExchangeTransport => (httpExchange: HttpExchange) =>
+export const LocalFileSystemTransport = (filename: string): HttpExchangeTransport => (httpExchange: HttpExchange) =>
   new Promise((resolve, reject) => {
     try {
       fs.appendFileSync(filename, JSON.stringify(httpExchange) + "\n");
@@ -31,11 +21,7 @@ export const LocalFileSystemTransport = (
     }
   });
 
-export default (options: Options) => async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
+export default (options: Options) => async (req: Request, res: Response, next: NextFunction) => {
   const oldWrite = res.write;
   const oldEnd = res.end;
 
@@ -43,20 +29,12 @@ export default (options: Options) => async (
 
   const chunks: Buffer[] = [];
 
-  res.write = (
-    thingOne: any,
-    thingTwo?: string | WriteCb,
-    thingThree?: WriteCb
-  ) => {
+  res.write = (thingOne: any, thingTwo?: string | WriteCb, thingThree?: WriteCb) => {
     chunks.push(Buffer.from(thingOne));
     return oldWrite.apply(res, [
       thingOne,
       typeof thingTwo === "string" ? thingTwo : "utf8",
-      thingThree === undefined &&
-      thingTwo !== undefined &&
-      typeof thingTwo !== "string"
-        ? thingTwo
-        : thingThree
+      thingThree === undefined && thingTwo !== undefined && typeof thingTwo !== "string" ? thingTwo : thingThree,
     ]);
   };
 
@@ -73,13 +51,13 @@ export default (options: Options) => async (
       pathname: req.path,
       query: req.query,
       protocol: req.protocol.toLowerCase() as HttpProtocol,
-      body: typeof req.body === "string" ? req.body : JSON.stringify(req.body)
+      body: typeof req.body === "string" ? req.body : JSON.stringify(req.body),
     });
 
     const response = HttpResponseBuilder.from({
       statusCode: res.statusCode,
       body,
-      headers: res.getHeaders() as { string: string | string[] }
+      headers: res.getHeaders() as { string: string | string[] },
     });
 
     const exchange: HttpExchange = { request, response };
@@ -91,11 +69,7 @@ export default (options: Options) => async (
     return oldEnd.apply(res, [
       thingOne,
       typeof thingTwo === "string" ? thingTwo : "utf8",
-      thingThree === undefined &&
-      thingTwo !== undefined &&
-      typeof thingTwo !== "string"
-        ? thingTwo
-        : thingThree
+      thingThree === undefined && thingTwo !== undefined && typeof thingTwo !== "string" ? thingTwo : thingThree,
     ]);
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export default (options: Options) => async (req: Request, res: Response, next: N
       headers: req.headers as { string: string | string[] },
       host: req.hostname,
       method: req.method.toLowerCase() as HttpMethod,
-      path: req.originalUrl,
+      path: fullPath,
       protocol: req.protocol.toLowerCase() as HttpProtocol,
       body: typeof req.body === "string" ? req.body : JSON.stringify(req.body),
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,12 +44,13 @@ export default (options: Options) => async (req: Request, res: Response, next: N
     }
     const body = Buffer.concat(chunks).toString("utf8");
 
-    const request = HttpRequestBuilder.fromPathnameAndQuery({
+    const fullPath = req.originalUrl;
+
+    const request = HttpRequestBuilder.fromPath({
       headers: req.headers as { string: string | string[] },
       host: req.hostname,
       method: req.method.toLowerCase() as HttpMethod,
-      pathname: req.path,
-      query: req.query,
+      path: req.originalUrl,
       protocol: req.protocol.toLowerCase() as HttpProtocol,
       body: typeof req.body === "string" ? req.body : JSON.stringify(req.body),
     });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -86,8 +86,14 @@ describe("middleware", () => {
 
     app.use("/route", route);
 
-    await request(app).get("/route/bar");
+    await request(app).get("/route/bar?q=a");
 
     expect(exchanges).toHaveLength(1);
+
+    const exchange = exchanges[0];
+
+    expect(exchange.request.pathname).toBe("/route/bar");
+    expect(exchange.request.path).toBe("/route/bar?q=a");
+    expect(exchange.request.query.toJSON()).toEqual({ q: "a" });
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -9,9 +9,7 @@ const TEST_JSONL = "foo.jsonl";
 const readExchanges = (jsonlFilename: string): HttpExchange[] => {
   const jsonlStr = fs.readFileSync(jsonlFilename, { encoding: "utf-8" });
   const exchanges: HttpExchange[] = [];
-  HttpExchangeReader.fromJsonLines(jsonlStr, exchange =>
-    exchanges.push(exchange)
-  );
+  HttpExchangeReader.fromJsonLines(jsonlStr, exchange => exchanges.push(exchange));
   return exchanges;
 };
 
@@ -26,7 +24,7 @@ describe("middleware", () => {
 
     app.use(
       middleware({
-        transports: [LocalFileSystemTransport(TEST_JSONL)]
+        transports: [LocalFileSystemTransport(TEST_JSONL)],
       })
     );
     app.get("/foo", (_, res) => res.send("Hello World!"));
@@ -56,7 +54,7 @@ describe("middleware", () => {
 
     app.use(
       middleware({
-        transports: []
+        transports: [],
       })
     );
     app.get("/bar", (_, res) => res.json({ hello: "world" }));
@@ -64,7 +62,32 @@ describe("middleware", () => {
     await request(app)
       .get("/bar")
       .expect(200, {
-        hello: "world"
+        hello: "world",
       });
+  });
+  test("correctly writes the path at routes", async () => {
+    const app = express();
+
+    const exchanges: HttpExchange[] = [];
+
+    const transport = (exchange: HttpExchange) => {
+      exchanges.push(exchange);
+      return Promise.resolve();
+    };
+
+    app.use(
+      middleware({
+        transports: [transport],
+      })
+    );
+
+    const route = express.Router();
+    route.get("/bar", (_, res) => res.json({ hello: "world" }));
+
+    app.use("/route", route);
+
+    await request(app).get("/route/bar");
+
+    expect(exchanges).toHaveLength(1);
   });
 });


### PR DESCRIPTION
- Fixes a bug where a request to `/route/asdf` with a mounted route at `/route` would result in `request.path` being `/asdf`. Not sure if `req.originalUrl` is what one should use here but it looks ok.
- Also added `.prettierrc.yaml` as otherwise it's not really defined what prettier should do