### PR TITLE
[MEM-171] Rename Meeshkan to Mem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CircleCI](https://circleci.com/gh/meeshkan/express-middleware.svg?style=svg)](https://circleci.com/gh/meeshkan/express-middleware)
 [![npm version](https://img.shields.io/npm/v/@meeshkanml/express-middleware.svg)](https://npmjs.org/package/@meeshkanml/express-middleware)
 
-# Meeshkan express middleware
+# Mem Express Middleware
 
 Express server middleware to log requests and responses in the [HTTP Types](https://meeshkan.github.io/http-types/) format.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@meeshkanml/express-middleware",
   "version": "0.0.6",
-  "description": "Express middleware to create .jsonl files for consumption by Meeshkan.",
+  "description": "Express middleware to create .jsonl files for consumption by Mem.",
   "main": "dist/index.js",
   "repository": "https://github.com/meeshkan/express-middleware",
   "author": "Meeshkan",


### PR DESCRIPTION
Blocked by https://github.com/meeshkan/meeshkan/pull/186

As decided in the new product discussions, we will be renaming this product to `Mem` in favor of our new product having the `Meeshkan` name.